### PR TITLE
Test nits

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ pep8==1.5.7
 py==1.4.26
 pyflakes==0.8.1
 pytest==2.7.0
+six==1.9.0

--- a/tests/random_object_id/random_object_id_test.py
+++ b/tests/random_object_id/random_object_id_test.py
@@ -1,20 +1,15 @@
+import contextlib
 import re
 import sys
 
-from contextlib import contextmanager
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 import mock
+from six.moves import cStringIO
 
 from random_object_id.random_object_id import \
     gen_random_object_id, parse_args, main
 
 
-@contextmanager
+@contextlib.contextmanager
 def captured_output():
     new_out = StringIO()
     old_out = sys.stdout
@@ -25,16 +20,16 @@ def captured_output():
         sys.stdout = old_out
 
 
+def test_gen_random_object_id():
+    assert re.match('[0-9a-f]{24}', gen_random_object_id())
+
+
 def test_gen_random_object_id_time():
     with mock.patch('time.time') as mock_time:
         mock_time.return_value = 1429506585.786924
         object_id = gen_random_object_id()
 
     assert re.match('55348a19', object_id)
-
-
-def test_gen_random_object_id_length():
-    assert len(gen_random_object_id()) == 24
 
 
 def test_parse_args():

--- a/tests/random_object_id/random_object_id_test.py
+++ b/tests/random_object_id/random_object_id_test.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 import mock
-from six.moves import cStringIO
+import six
 
 from random_object_id.random_object_id import \
     gen_random_object_id, parse_args, main
@@ -11,10 +11,9 @@ from random_object_id.random_object_id import \
 
 @contextlib.contextmanager
 def captured_output():
-    new_out = StringIO()
     old_out = sys.stdout
     try:
-        sys.stdout = new_out
+        sys.stdout = six.StringIO()
         yield sys.stdout
     finally:
         sys.stdout = old_out


### PR DESCRIPTION
- Assert entire ObjectId body instead of just length
- Use `six` instead of `try-catch` for `StringIO` import
- Import all of `contextlib` to avoid `from` statement
